### PR TITLE
feat: implement service-only vs full server installation pattern

### DIFF
--- a/.claude/development_notes.md
+++ b/.claude/development_notes.md
@@ -1,0 +1,37 @@
+# Ansible Cloudy Development Notes
+
+## Version Status
+- Current version: Pre-v1.1 (not yet released)
+- Backward compatibility is NOT a concern for changes made before v1.1 release
+
+## Architecture Decisions
+
+### Service Installation Pattern (Implemented)
+As of this change, we have two distinct installation patterns:
+
+1. **Service-only commands** (`psql`, `nginx`, `redis`, etc.)
+   - Install ONLY the specified service
+   - NO automatic dependency installation (no security, no base)
+   - For advanced users who already have secured/prepared servers
+   - Example: `cli psql --install`
+
+2. **Full server commands** (`psql-server`, `nginx-server`, etc.)
+   - Complete server setup: security → base → service
+   - For new server deployments
+   - Ensures proper hardening and configuration
+   - Example: `cli psql-server --install`
+
+### Special Cases
+- `pgbouncer`: Always standalone (no -server variant) as it's installed on existing web servers
+- `django-server` and `nodejs-server`: Also install pgbouncer automatically
+- Environment (dev/ci/prod) is orthogonal to this pattern and controlled by:
+  - Default: dev
+  - Flags: --dev, --ci, --prod
+  - Vault configuration
+
+### Rationale
+This pattern provides clarity and flexibility:
+- Clear user intent (service vs full server)
+- No surprises for advanced users
+- Safe defaults for new users
+- Clean separation of concerns

--- a/dev/cli/cmd/argument_parser.py
+++ b/dev/cli/cmd/argument_parser.py
@@ -25,10 +25,12 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=ColoredHelpFormatter,
         epilog=f"""
 {Colors.YELLOW}Quick Start:{Colors.NC}
-  {Colors.GREEN}cli security --install{Colors.NC}         Setup server security (run first!)
-  {Colors.GREEN}cli base --install{Colors.NC}             Setup base configuration
-  {Colors.GREEN}cli psql --install{Colors.NC}             Install PostgreSQL
-  {Colors.GREEN}cli finalize --install{Colors.NC}         Finalize with upgrades
+  {Colors.GREEN}cli psql-server --install{Colors.NC}      Full PostgreSQL server (security + base + psql)
+  {Colors.GREEN}cli nginx-server --install{Colors.NC}     Full Nginx server (security + base + nginx)
+  
+  {Colors.BLUE}Or for existing secured servers:{Colors.NC}
+  {Colors.GREEN}cli psql --install{Colors.NC}             Install only PostgreSQL
+  {Colors.GREEN}cli nginx --install{Colors.NC}            Install only Nginx
 
 {Colors.YELLOW}Getting Help:{Colors.NC}
   {Colors.GREEN}cli --help{Colors.NC}                     Show this help
@@ -383,6 +385,79 @@ def register_service_subparsers(subparsers, common_parser, install_parser):
         formatter_class=ColoredHelpFormatter,
         help='All-in-one server setup',
         description=f"{Colors.CYAN}Standalone Service - Complete server with all services{Colors.NC}"
+    )
+    
+    # ===== Server Variants (-server commands) =====
+    # These commands include full server setup: security → base → service
+    
+    # PostgreSQL server
+    psql_server_parser = subparsers.add_parser(  # noqa: F841
+        'psql-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='PostgreSQL full server setup (security + base + psql)',
+        description=f"{Colors.CYAN}PostgreSQL Server - Complete PostgreSQL server deployment{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → PostgreSQL{Colors.NC}"
+    )
+    
+    # PostGIS server
+    postgis_server_parser = subparsers.add_parser(  # noqa: F841
+        'postgis-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='PostGIS full server setup (security + base + postgis)',
+        description=f"{Colors.CYAN}PostGIS Server - Complete spatial database server{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → PostGIS{Colors.NC}"
+    )
+    
+    # Redis server
+    redis_server_parser = subparsers.add_parser(  # noqa: F841
+        'redis-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='Redis full server setup (security + base + redis)',
+        description=f"{Colors.CYAN}Redis Server - Complete Redis cache server{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → Redis{Colors.NC}"
+    )
+    
+    # Nginx server
+    nginx_server_parser = subparsers.add_parser(  # noqa: F841
+        'nginx-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='Nginx full server setup (security + base + nginx)',
+        description=f"{Colors.CYAN}Nginx Server - Complete web server deployment{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → Nginx{Colors.NC}"
+    )
+    
+    # Django server
+    django_server_parser = subparsers.add_parser(  # noqa: F841
+        'django-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='Django full server setup (security + base + django + pgbouncer)',
+        description=f"{Colors.CYAN}Django Server - Complete Django application server{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → Django → PgBouncer{Colors.NC}"
+    )
+    
+    # Node.js server
+    nodejs_server_parser = subparsers.add_parser(  # noqa: F841
+        'nodejs-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='Node.js full server setup (security + base + nodejs + pgbouncer)',
+        description=f"{Colors.CYAN}Node.js Server - Complete Node.js application server{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → Node.js → PgBouncer{Colors.NC}"
+    )
+    
+    # OpenVPN server
+    openvpn_server_parser = subparsers.add_parser(  # noqa: F841
+        'openvpn-server',
+        parents=[install_parser],
+        formatter_class=ColoredHelpFormatter,
+        help='OpenVPN full server setup (security + base + openvpn)',
+        description=f"{Colors.CYAN}OpenVPN Server - Complete VPN server deployment{Colors.NC}\n"
+                    f"{Colors.YELLOW}Includes: Security hardening → Base configuration → OpenVPN{Colors.NC}"
     )
     
     return subparsers


### PR DESCRIPTION
Split installation commands into two distinct patterns:
- Service commands (psql, nginx, etc.): Install only the service, no dependencies
- Server commands (psql-server, nginx-server, etc.): Full setup with security → base → service

Key changes:
- Added -server variants for all major services (psql, redis, nginx, django, nodejs, openvpn)
- Modified DependencyManager to support the new architecture
- Updated CommandRouter to route -server variants to generic handler
- Changed dependency mappings: regular services have no dependencies by default
- Special handling: django-server and nodejs-server also install pgbouncer
- Updated help text to clarify the distinction

This provides clarity for users and flexibility for different deployment scenarios:
- Advanced users can install services on pre-secured servers
- New users get complete, hardened server setups with -server commands

🤖 Generated with [Claude Code](https://claude.ai/code)